### PR TITLE
Fix a race condition

### DIFF
--- a/platform-configure.sh
+++ b/platform-configure.sh
@@ -161,6 +161,6 @@ fi
 
 if [ "$REBOOT" = true ]; then
   echo "Rebooting after update."
-  shutdown --reboot now "Rebooting system for experimental-platform update."
+  shutdown --reboot 1 "Rebooting system for experimental-platform update."
   exit 0
 fi


### PR DESCRIPTION
This fixes a race condition between `shutdown` and `exit 0` when the script is called via ssh on a fast machine. This regularly happens in our CI integration tests.
