### PR TITLE
display the hostname from the hostname file instead of using the generated one

### DIFF
--- a/platform-configure.sh
+++ b/platform-configure.sh
@@ -21,6 +21,7 @@ CONTAINER_NAME="configure"
 CHANNEL_FILE=/etc/protonet/system/channel
 UPDATE_ENGINE_CONFIG=/etc/coreos/update.conf
 IMAGE_STATE_DIR=/etc/protonet/system/images
+HOSTNAME_FILE=/etc/protonet/hostname
 
 PLATFORM_INITIAL_HOSTNAME=${PLATFORM_INITIAL_HOSTNAME:=$(cat /dev/urandom | tr -dc 'a-z' | fold -w 6 | head -n 1)}
 PLATFORM_INSTALL_REBOOT=${PLATFORM_INSTALL_REBOOT:=false}
@@ -169,10 +170,10 @@ function install_platform() {
   $DOCKER rm $CONTAINER_NAME 2>/dev/null || true
 
   mkdir -p /etc/protonet
-  [[ -d /etc/protonet/hostname ]] && rm -rf /etc/protonet/hostname
-  if [[ ! -f /etc/protonet/hostname ]]; then
+  [[ -d $HOSTNAME_FILE ]] && rm -rf /etc/protonet/hostname
+  if [[ ! -f $HOSTNAME_FILE ]]; then
     echo "Setting hostname to '$PLATFORM_INITIAL_HOSTNAME'."
-    echo $PLATFORM_INITIAL_HOSTNAME > /etc/protonet/hostname
+    echo $PLATFORM_INITIAL_HOSTNAME > $HOSTNAME_FILE
   fi
 
   $DOCKER run --rm --name=$CONTAINER_NAME \
@@ -232,13 +233,11 @@ function install_platform() {
     update_os_image || true
   fi
 
-  if [[ "$PLATFORM_INITIAL_HOSTNAME" != "" ]]; then
-    echo "===================================================================="
-    echo "After the reboot your experimental platform will be reachable via:"
-    echo "http://$PLATFORM_INITIAL_HOSTNAME.local"
-    echo "(don't worry, you can change this later)"
-    echo "===================================================================="
-  fi
+  echo "===================================================================="
+  echo "After the reboot your experimental platform will be reachable via:"
+  echo "http://$(cat $HOSTNAME_FILE).local"
+  echo "(don't worry, you can change this later)"
+  echo "===================================================================="
 
   if [ "$PLATFORM_INSTALL_REBOOT" = true ]; then
     echo "Rebooting after update."


### PR DESCRIPTION
now that the hostname is always generated and not just if the file doesnt exist yet, the check for the empty hostname variable doesn't quite cut it anymore. instead we just display the current hostname from the hostname file at the end of the script run
