### PR TITLE
use update_engine_client directly

### DIFF
--- a/platform-configure.sh
+++ b/platform-configure.sh
@@ -180,11 +180,7 @@ function install_platform() {
     if [[ "${PLATFORM_INSTALL_OSUPDATE}" = true ]]; then
         echo "CoreOS System Update: START"
         set_status "osupdate"
-        if [[ -x ${PLATFORM_BASENAME}/opt/bin/update_os ]]; then
-            ${PLATFORM_BASENAME}/opt/bin/update_os && echo "CoreOS System Update: DONE" || echo "CoreOS System Update: ERROR"
-        else
-            echo "CoreOS System Update: Script not found. Please try again  "
-        fi
+        update_engine_client -update && echo "CoreOS System Update: DONE" || echo "CoreOS System Update: ERROR"
     fi
 
   set_status "configuring"


### PR DESCRIPTION
The `update_os` script was a transition tool used in the early days of the Platform to update vanilla CoreOS box to our flavour. Since we no longer begin with the vanilla images, the signing key juggling within this script is no longer necessary.

A PR to remove the `update_os` tool from the `configure` image will soon follow.